### PR TITLE
feat(membership): replace mailto CTA with BtMembershipRequestForm

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,5 @@
 VITE_BETTER_TOGETHER_API_URI=http://localhost:3000
+
+# The slug/ID of the host community for which membership requests are submitted.
+# Set to the Better Together community's slug in production (e.g. better-together).
+VITE_BT_HOST_COMMUNITY_ID=

--- a/src/components/membership_request/BtMembershipRequestForm.vue
+++ b/src/components/membership_request/BtMembershipRequestForm.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="bt-membership-request-form">
+    <!-- Success state -->
+    <div
+      v-if="submitted"
+      class="bt-membership-request-form__success"
+      role="status"
+    >
+      <h3>{{ t('bt.membership_requests.success_heading') }}</h3>
+      <p>{{ t('bt.membership_requests.success_body') }}</p>
+      <BButton
+        variant="outline-primary"
+        @click="reset"
+      >
+        {{ t('bt.actions.close') }}
+      </BButton>
+    </div>
+
+    <!-- Form state -->
+    <BForm
+      v-else
+      class="bt-membership-request-form__form"
+      @submit.prevent="submit"
+    >
+      <BAlert
+        v-if="error"
+        variant="danger"
+        :model-value="true"
+      >
+        <strong>{{ t('bt.membership_requests.error_prefix') }}</strong>
+        {{ error }}
+      </BAlert>
+
+      <BFormGroup
+        :label="t('bt.membership_requests.name_label')"
+        label-for="mr-requestor-name"
+      >
+        <BFormInput
+          id="mr-requestor-name"
+          v-model="form.requestorName"
+          type="text"
+          required
+          :placeholder="t('bt.membership_requests.name_placeholder')"
+          :disabled="loading"
+        />
+      </BFormGroup>
+
+      <BFormGroup
+        :label="t('bt.membership_requests.email_label')"
+        label-for="mr-requestor-email"
+      >
+        <BFormInput
+          id="mr-requestor-email"
+          v-model="form.requestorEmail"
+          type="email"
+          required
+          :placeholder="t('bt.membership_requests.email_placeholder')"
+          :disabled="loading"
+        />
+      </BFormGroup>
+
+      <BFormGroup
+        :label="t('bt.membership_requests.referral_label')"
+        label-for="mr-referral-source"
+      >
+        <BFormInput
+          id="mr-referral-source"
+          v-model="form.referralSource"
+          type="text"
+          :placeholder="t('bt.membership_requests.referral_placeholder')"
+          :disabled="loading"
+        />
+      </BFormGroup>
+
+      <BFormGroup
+        :label="t('bt.membership_requests.description_label')"
+        label-for="mr-description"
+      >
+        <BFormTextarea
+          id="mr-description"
+          v-model="form.description"
+          required
+          rows="4"
+          :placeholder="t('bt.membership_requests.description_placeholder')"
+          :disabled="loading"
+        />
+      </BFormGroup>
+
+      <BButton
+        type="submit"
+        variant="primary"
+        class="w-100"
+        :disabled="loading"
+      >
+        {{ loading ? t('bt.membership_requests.submitting') : t('bt.membership_requests.submit') }}
+      </BButton>
+    </BForm>
+  </div>
+</template>
+
+<script setup>
+import { useI18n } from 'vue-i18n'
+import { BAlert, BButton, BForm, BFormGroup, BFormInput, BFormTextarea } from 'bootstrap-vue-next'
+import { useMembershipRequest } from '../../composables/useMembershipRequest'
+
+const props = defineProps({
+  communityId: {
+    type: String,
+    required: true,
+  },
+})
+
+const { t } = useI18n()
+const { form, loading, error, submitted, submit, reset } = useMembershipRequest(props.communityId)
+</script>

--- a/src/composables/useMembershipRequest.js
+++ b/src/composables/useMembershipRequest.js
@@ -1,0 +1,78 @@
+import { reactive, ref } from 'vue'
+import axios from 'axios'
+
+/**
+ * Composable for submitting a public community membership request.
+ *
+ * Membership requests are a one-shot form submission — not an offline-first
+ * resource — so we POST directly to the JSONAPI endpoint rather than going
+ * through the SQLite-backed useResource layer.
+ *
+ * Usage:
+ *   const { form, loading, error, submitted, submit, reset } = useMembershipRequest(communityId)
+ */
+export function useMembershipRequest(communityId) {
+  const form = reactive({
+    requestorName: '',
+    requestorEmail: '',
+    referralSource: '',
+    description: '',
+  })
+
+  const loading = ref(false)
+  const error = ref(null)
+  const submitted = ref(false)
+
+  async function submit() {
+    loading.value = true
+    error.value = null
+
+    const payload = {
+      data: {
+        type: 'membership_requests',
+        attributes: {
+          requestor_name: form.requestorName,
+          requestor_email: form.requestorEmail,
+          referral_source: form.referralSource,
+          description: form.description,
+          name: `Membership request from ${form.requestorName}`,
+          status: 'open',
+          urgency: 'normal',
+          target_type: 'BetterTogether::Community',
+          target_id: communityId,
+        },
+      },
+    }
+
+    try {
+      const baseUrl = import.meta.env.VITE_BETTER_TOGETHER_API_URI || ''
+      await axios.post(`${baseUrl}/api/v1/membership_requests`, payload, {
+        headers: {
+          'Content-Type': 'application/vnd.api+json',
+          Accept: 'application/vnd.api+json',
+        },
+      })
+      submitted.value = true
+    } catch (e) {
+      const jsonApiErrors = e.response?.data?.errors
+      if (jsonApiErrors?.length) {
+        error.value = jsonApiErrors.map((err) => err.detail).join(', ')
+      } else {
+        error.value = e.message || 'An unexpected error occurred.'
+      }
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function reset() {
+    form.requestorName = ''
+    form.requestorEmail = ''
+    form.referralSource = ''
+    form.description = ''
+    error.value = null
+    submitted.value = false
+  }
+
+  return { form, loading, error, submitted, submit, reset }
+}

--- a/src/pages/Membership.vue
+++ b/src/pages/Membership.vue
@@ -29,21 +29,24 @@
         </ul>
       </div>
     </div>
-    <div class="cta">
-      <RouterLink
-        to="/contact"
-        :title="t('btv.pages.membership.cta')"
-        class="btn btn-primary"
-      >
-        {{ t('btv.pages.membership.cta') }}
-      </RouterLink>
+    <div class="row mt-4">
+      <div class="col-md-8">
+        <!-- TODO: replace local import with @bettertogether/community-engine-vue once
+             BtMembershipRequestForm is published in CEV >= 0.3.0 -->
+        <BtMembershipRequestForm :community-id="hostCommunityId" />
+      </div>
     </div>
   </section>
 </template>
 
 <script setup>
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { RouterLink } from 'vue-router'
+import BtMembershipRequestForm from '@/components/membership_request/BtMembershipRequestForm.vue'
 
 const { t } = useI18n()
+
+const hostCommunityId = computed(
+  () => import.meta.env.VITE_BT_HOST_COMMUNITY_ID || null
+)
 </script>

--- a/tests/unit/pages/Membership.spec.js
+++ b/tests/unit/pages/Membership.spec.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { shallowMount } from '@vue/test-utils'
+import Membership from '@/pages/Membership.vue'
+
+vi.mock('@/components/membership_request/BtMembershipRequestForm.vue', () => ({
+  default: { name: 'BtMembershipRequestForm', template: '<div class="bt-membership-request-form-stub" />', props: ['communityId'] },
+}))
+
+describe('Membership.vue', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = shallowMount(Membership, {
+      global: {
+        mocks: { t: (key) => key },
+      },
+    })
+  })
+
+  it('renders the membership heading', () => {
+    expect(wrapper.find('h2').exists()).toBe(true)
+  })
+
+  it('renders the BtMembershipRequestForm', () => {
+    expect(wrapper.findComponent({ name: 'BtMembershipRequestForm' }).exists()).toBe(true)
+  })
+
+  it('does not render the old RouterLink CTA', () => {
+    expect(wrapper.findComponent({ name: 'RouterLink' }).exists()).toBe(false)
+  })
+
+  it('passes hostCommunityId to the form', () => {
+    const form = wrapper.findComponent({ name: 'BtMembershipRequestForm' })
+    // VITE_BT_HOST_COMMUNITY_ID is not set in test env — communityId should be null
+    expect(form.props('communityId')).toBeNull()
+  })
+
+  it('renders membership types list', () => {
+    const items = wrapper.findAll('ul li')
+    expect(items.length).toBeGreaterThanOrEqual(2)
+  })
+})


### PR DESCRIPTION
## Summary

Replaces the static RouterLink CTA on the Membership page with a self-service `BtMembershipRequestForm`.

## Changes

- **`src/pages/Membership.vue`** — remove RouterLink CTA; render `BtMembershipRequestForm` with `hostCommunityId` from env
- **`src/components/membership_request/BtMembershipRequestForm.vue`** — copied from CEV `feat/membership-request-form` (will import from package once CEV >= 0.3.0 is published)
- **`src/composables/useMembershipRequest.js`** — JSONAPI POST to `/api/v1/membership_requests`; axios-based, not offline-first
- **`.env.sample`** — document `VITE_BT_HOST_COMMUNITY_ID`
- **`tests/unit/pages/Membership.spec.js`** — 5 Vitest specs (heading, form presence, no RouterLink, communityId prop, types list) ✅

## Test results

```
Tests  24 passed (24) — all BTV tests
```

## Depends on

- CE Rails: better-together-org/community-engine-rails#1356 (MembershipRequest API)
- CEV: better-together-org/community-engine-vue#99 (BtMembershipRequestForm)

## TODO

Once CEV #99 is merged and >= 0.3.0 is published to npm, replace the local component/composable with:
```js
import { BtMembershipRequestForm, useMembershipRequest } from '@bettertogether/community-engine-vue'
```